### PR TITLE
Fix env file error

### DIFF
--- a/xserver-auto-renew/settings.py
+++ b/xserver-auto-renew/settings.py
@@ -3,7 +3,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     id_vps: str = Field()
 
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
 
 class LoginSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     username: str = Field()
     password: str = Field()


### PR DESCRIPTION
`.env` ファイルで main と login において、必要以外の変数が置かれている場合にエラーになるシチュを修正